### PR TITLE
Fix duplicate global variable

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -49,9 +49,6 @@ class ConversationInfo(BaseModel):
     created_at: str
     message_count: int
 
-# Variable global para el SwarmMaster principal
-global_swarm_master: Optional[SwarmMaster] = None
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """


### PR DESCRIPTION
## Summary
- fix duplicated `global_swarm_master` definition in `api_server`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a3877c9c8328a1c3047cf3a735e6