### PR TITLE
Add LangChain and RAG documentation

### DIFF
--- a/README_LANGCHAIN.md
+++ b/README_LANGCHAIN.md
@@ -1,0 +1,52 @@
+# 📚 Integración de LangChain y Gestión de Agentes con LangGraph
+
+Este documento detalla cómo se emplean las funcionalidades de LangChain en el proyecto y la forma en la que se coordina el sistema multi‑agente mediante LangGraph.
+
+## 1. Estructura de Agentes
+
+Los agentes del sistema heredan de `BaseAgent`, que encapsula la lógica común para interactuar con el modelo de lenguaje y la memoria de conversación. El método `run` prepara los mensajes, incorpora el historial reciente y guarda cada turno en la memoria:
+
+```python
+# src/agents/base_agent.py
+... (ver líneas 32‑84)
+```
+
+Los agentes especializados (por ejemplo `ConceptMapAgent`, `LessonPlanAgent`, etc.) simplemente proporcionan un `prompt_template` y un objetivo.
+
+Para agentes que necesitan invocar herramientas externas se extiende `BaseToolCallingAgent`. Esta clase utiliza `create_tool_calling_agent` y `AgentExecutor` de LangChain para manejar la ejecución de herramientas declaradas mediante `BaseTool`:
+
+```python
+# src/agents/base_tool_calling_agent.py
+... (ver líneas 24‑39 y 66‑97)
+```
+
+## 2. Planificadores
+
+Los distintos planificadores heredan de `BasePlanner`. Esta clase usa `ChatOpenAI` combinado con `with_structured_output` para generar un plan estructurado (`Plan`) con los pasos a realizar. Después ejecuta secuencialmente cada paso delegándolo al agente correspondiente:
+
+```python
+# src/agents/base_planner.py
+... (ver líneas 36‑88 y 138‑173)
+```
+
+Cada planificador concreto define su objetivo y los agentes que lo componen. La orquestación garantiza que todos ellos compartan la misma memoria de conversación cuando esta se encuentra habilitada.
+
+## 3. Coordinación con LangGraph
+
+El componente de alto nivel es `SwarmMaster`, encargado de seleccionar el planificador adecuado y mantener un registro centralizado de la conversación. Se apoya en la inicialización definida en `start_app.py` y utiliza elementos de LangGraph como `StateGraph` para estructurar el flujo de ejecución:
+
+```python
+# src/agents/swarm_master.py
+... (ver líneas 1‑34 y 52‑83)
+```
+
+Aunque el grafo se mantiene simple, esta integración permite ampliar el sistema con flujos más complejos si fuese necesario.
+
+## 4. Inicialización de Componentes
+
+El módulo `start_app.py` construye todos los agentes, planificadores y modelos LLM. También configura la memoria y genera mapas de acceso rápido para las invocaciones posteriores.
+
+La función `initialize_swarm_master` devuelve un diccionario con todos estos elementos listos para ser usados por `SwarmMaster`.
+
+Con esta arquitectura, LangChain se emplea para la gestión de prompts, herramientas y planes, mientras que LangGraph proporciona el marco para coordinar a los agentes de manera modular.
+

--- a/README_RAG.md
+++ b/README_RAG.md
@@ -1,0 +1,40 @@
+# 🛠️ Herramientas RAG y Métodos de Consulta
+
+Este documento describe las herramientas de recuperación de información utilizadas en SAPE y cómo se integran en el agente RAG.
+
+## 1. Ingesta de Documentos
+
+La clase `DocumentIngestor` se encarga de procesar archivos y almacenarlos en la base de datos vectorial `pgvector`. Utiliza `OpenAIEmbeddings` para generar los vectores y `RecursiveCharacterTextSplitter` para dividir los textos.
+
+```python
+# src/utils/rag/document_ingestor.py
+... (ver líneas 18‑46 y 48‑67)
+```
+
+El método `ingest` admite metadatos opcionales que permiten filtrar por asignatura, tema o nivel educativo.
+
+## 2. Búsqueda en la Base de Conocimientos
+
+Dentro de `a_it_rag_agent.py` se definen dos herramientas con el decorador `@tool` de LangChain:
+
+- **`search_knowledge_base`**: realiza una búsqueda por similitud y filtra los resultados según un umbral de relevancia.
+- **`search_by_metadata_filter`**: permite añadir filtros de metadata como asignatura, tema o curso.
+
+```python
+# src/agents/a_it_rag_agent.py
+... (ver líneas 11‑50 y 74‑142)
+```
+
+Ambas funciones devuelven un texto formateado con las fuentes encontradas. Estas herramientas se registran en `RagAgent`, una subclase de `BaseToolCallingAgent` que puede invocarlas durante la conversación:
+
+```python
+# src/agents/a_it_rag_agent.py
+... (ver líneas 144‑157)
+```
+
+## 3. Uso desde los Planificadores
+
+Los planificadores que requieren investigación delegan en `RagAgent` las consultas necesarias. De esta forma, el resto de agentes recibe la información relevante ya filtrada y puede centrarse en generar el contenido solicitado.
+
+Al compartir la misma memoria de conversación, los resultados recuperados quedan disponibles para pasos posteriores del plan.
+


### PR DESCRIPTION
## Summary
- document how LangChain agents and planners work with LangGraph
- explain the RAG utilities and search tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a88ecec88328b1d4101be4a74ce2